### PR TITLE
Check that every required target is installed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,30 @@ fn do_main() -> Result<()> {
         );
     };
 
+    let mut doc_targets = Vec::new();
+    if !args.target.is_empty() {
+        for target in &args.target {
+            doc_targets.push(target);
+        }
+    } else if proc_macro {
+        // Ignore selected target because proc macro can only be built for host.
+    } else if args.open {
+        // When using `--open`, only a single target is supported.
+        if let Some(default_target) = &metadata.default_target {
+            doc_targets.push(default_target);
+        } else if let Some(targets) = &metadata.targets {
+            if let Some(default_target) = targets.first() {
+                doc_targets.push(default_target);
+            }
+        }
+    } else if let Some(targets) = &metadata.targets {
+        for target in targets {
+            doc_targets.push(target);
+        }
+    } else if let Some(default_target) = &metadata.default_target {
+        doc_targets.push(default_target);
+    }
+
     let mut cargo_rustdoc = cargo_command();
     cargo_rustdoc.arg("rustdoc");
     cargo_rustdoc.arg("-Zunstable-options");
@@ -111,32 +135,9 @@ fn do_main() -> Result<()> {
         cargo_rustdoc.arg("--no-default-features");
     }
 
-    if !args.target.is_empty() {
-        for target in args.target {
-            cargo_rustdoc.arg("--target");
-            cargo_rustdoc.arg(target);
-        }
-    } else if proc_macro {
-        // Ignore selected target because proc macro can only be built for host.
-    } else if args.open {
-        // When using `--open`, only a single target is supported.
-        if let Some(default_target) = &metadata.default_target {
-            cargo_rustdoc.arg("--target");
-            cargo_rustdoc.arg(default_target);
-        } else if let Some(targets) = &metadata.targets {
-            if let Some(default_target) = targets.first() {
-                cargo_rustdoc.arg("--target");
-                cargo_rustdoc.arg(default_target);
-            }
-        }
-    } else if let Some(targets) = &metadata.targets {
-        for target in targets {
-            cargo_rustdoc.arg("--target");
-            cargo_rustdoc.arg(target);
-        }
-    } else if let Some(default_target) = &metadata.default_target {
+    for target in doc_targets {
         cargo_rustdoc.arg("--target");
-        cargo_rustdoc.arg(default_target);
+        cargo_rustdoc.arg(target);
     }
 
     let mut rustflags = metadata.rustc_args.clone();


### PR DESCRIPTION
**Before:**

<details>
<summary>1450 lines of output</summary>

```console
error[E0463]: can't find crate for `std`
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `alloc`
   --> src/lib.rs:239:1
    |
239 | extern crate alloc;
    | ^^^^^^^^^^^^^^^^^^^ can't find crate

error[E0463]: can't find crate for `std`
 --> src/chain.rs:5:5
  |
5 | use std::vec;
  |     ^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/context.rs:3:5
  |
3 | use core::convert::Infallible;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/context.rs:4:5
  |
4 | use core::fmt::{self, Debug, Display, Write};
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/ensure.rs:3:5
  |
3 | use core::fmt::{self, Debug, Write};
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/ensure.rs:4:5
  |
4 | use core::mem::MaybeUninit;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/ensure.rs:5:5
  |
5 | use core::ptr;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/ensure.rs:6:5
  |
6 | use core::slice;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/ensure.rs:7:5
  |
7 | use core::str;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/error.rs:8:5
  |
8 | use core::any::TypeId;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/error.rs:9:5
  |
9 | use core::fmt::{self, Debug, Display};
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
  --> src/error.rs:10:5
   |
10 | use core::mem::ManuallyDrop;
   |     ^^^^ can't find crate
   |
   = note: the `x86_64-unknown-fuchsia` target may not be installed
   = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
   = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
  --> src/error.rs:12:5
   |
12 | use core::ptr;
   |     ^^^^ can't find crate
   |
   = note: the `x86_64-unknown-fuchsia` target may not be installed
   = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
   = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
  --> src/error.rs:13:5
   |
13 | use core::ptr::NonNull;
   |     ^^^^ can't find crate
   |
   = note: the `x86_64-unknown-fuchsia` target may not be installed
   = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
   = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
  --> src/error.rs:18:5
   |
18 | use core::ops::{Deref, DerefMut};
   |     ^^^^ can't find crate
   |
   = note: the `x86_64-unknown-fuchsia` target may not be installed
   = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
   = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/fmt.rs:4:5
  |
4 | use core::fmt::{self, Debug, Write};
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
  --> src/kind.rs:48:5
   |
48 | use core::fmt::{Debug, Display};
   |     ^^^^ can't find crate
   |
   = note: the `x86_64-unknown-fuchsia` target may not be installed
   = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
   = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/ptr.rs:2:5
  |
2 | use core::marker::PhantomData;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/ptr.rs:3:5
  |
3 | use core::ptr::NonNull;
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
 --> src/wrapper.rs:2:5
  |
2 | use core::fmt::{self, Debug, Display};
  |     ^^^^ can't find crate
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
   --> src/lib.rs:255:5
    |
255 | use core::fmt::Display;
    |     ^^^^ can't find crate
    |
    = note: the `x86_64-unknown-fuchsia` target may not be installed
    = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `std`
   --> src/lib.rs:261:5
    |
261 | use std::error::Error as StdError;
    |     ^^^ can't find crate
    |
    = note: the `x86_64-unknown-fuchsia` target may not be installed
    = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
   --> src/lib.rs:644:9
    |
644 |     use core::fmt::Arguments;
    |         ^^^^ can't find crate
    |
    = note: the `x86_64-unknown-fuchsia` target may not be installed
    = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
   --> src/lib.rs:651:13
    |
651 |     pub use core::result::Result::Err;
    |             ^^^^ can't find crate
    |
    = note: the `x86_64-unknown-fuchsia` target may not be installed
    = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
   --> src/lib.rs:653:13
    |
653 |     pub use core::{concat, format_args, stringify};
    |             ^^^^ can't find crate
    |
    = note: the `x86_64-unknown-fuchsia` target may not be installed
    = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0432]: unresolved imports `crate::StdError`, `crate::StdError`, `crate::StdError`, `crate::StdError`, `crate::StdError`
   --> src/chain.rs:2:5
    |
2   | use crate::StdError;
    |     ^^^^^^^^^^^^^^^
    |
   ::: src/context.rs:2:29
    |
2   | use crate::{Context, Error, StdError};
    |                             ^^^^^^^^
    |
   ::: src/error.rs:6:20
    |
6   | use crate::{Error, StdError};
    |                    ^^^^^^^^
    |
   ::: src/kind.rs:51:5
    |
51  | use crate::StdError;
    |     ^^^^^^^^^^^^^^^
    |
   ::: src/wrapper.rs:1:5
    |
1   | use crate::StdError;
    |     ^^^^^^^^^^^^^^^
    |
note: found an item that was configured out
   --> src/lib.rs:264:7
    |
264 | trait StdError: Debug + Display {
    |       ^^^^^^^^
note: found an item that was configured out
   --> src/lib.rs:264:7
    |
264 | trait StdError: Debug + Display {
    |       ^^^^^^^^
note: found an item that was configured out
   --> src/lib.rs:264:7
    |
264 | trait StdError: Debug + Display {
    |       ^^^^^^^^
note: found an item that was configured out
   --> src/lib.rs:264:7
    |
264 | trait StdError: Debug + Display {
    |       ^^^^^^^^
note: found an item that was configured out
   --> src/lib.rs:264:7
    |
264 | trait StdError: Debug + Display {
    |       ^^^^^^^^

error: cannot determine resolution for the macro `ptr::addr_of`
   --> src/error.rs:638:9
    |
638 |         ptr::addr_of!((*unerased.as_ptr())._object) as *mut E,
    |         ^^^^^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error: cannot determine resolution for the macro `ptr::addr_of`
   --> src/error.rs:679:17
    |
679 |                 ptr::addr_of!((*unerased.as_ptr())._object) as *mut E,
    |                 ^^^^^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error: cannot find attribute `derive` in this scope
  --> src/chain.rs:15:3
   |
15 | #[derive(Clone)]
   |   ^^^^^^

error: cannot find macro `format_args` in this scope
   --> src/context.rs:174:43
    |
174 |         Quoted(&mut *formatter).write_fmt(format_args!("{}", self.0))?;
    |                                           ^^^^^^^^^^^

error: cannot find macro `format_args` in this scope
  --> src/ensure.rs:83:33
   |
83 |     if fmt::write(&mut lhs_buf, format_args!("{:?}", lhs)).is_ok() {
   |                                 ^^^^^^^^^^^

error: cannot find macro `format_args` in this scope
  --> src/ensure.rs:85:37
   |
85 |         if fmt::write(&mut rhs_buf, format_args!("{:?}", rhs)).is_ok() {
   |                                     ^^^^^^^^^^^

error: cannot find macro `write` in this scope
 --> src/fmt.rs:8:9
  |
8 |         write!(f, "{}", Self::error(this))?;
  |         ^^^^^

error: cannot find macro `write` in this scope
  --> src/fmt.rs:12:17
   |
12 |                 write!(f, ": {}", cause)?;
   |                 ^^^^^

error: cannot find macro `write` in this scope
  --> src/fmt.rs:26:9
   |
26 |         write!(f, "{}", error)?;
   |         ^^^^^

error: cannot find macro `write` in this scope
  --> src/fmt.rs:29:13
   |
29 |             write!(f, "\n\nCaused by:")?;
   |             ^^^^^

error: cannot find macro `writeln` in this scope
  --> src/fmt.rs:32:17
   |
32 |                 writeln!(f)?;
   |                 ^^^^^^^

error: cannot find macro `write` in this scope
  --> src/fmt.rs:38:17
   |
38 |                 write!(indented, "{}", error)?;
   |                 ^^^^^

error: cannot find macro `write` in this scope
  --> src/fmt.rs:82:37
   |
82 |                     Some(number) => write!(self.inner, "{: >5}: ", number)?,
   |                                     ^^^^^

error: cannot find attribute `derive` in this scope
   --> src/lib.rs:400:3
    |
400 | #[derive(Clone)]
    |   ^^^^^^

error[E0463]: can't find crate for `std`
  --> src/context.rs:21:12
   |
21 |         E: std::error::Error + Send + Sync + 'static,
   |            ^^^ can't find crate
   |
   = note: the `x86_64-unknown-fuchsia` target may not be installed
   = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
   = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `core`
   --> src/lib.rs:454:33
    |
454 | pub type Result<T, E = Error> = core::result::Result<T, E>;
    |                                 ^^^^ can't find crate
    |
    = note: the `x86_64-unknown-fuchsia` target may not be installed
    = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
    = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0405]: cannot find trait `Send` in this scope
   --> src/backtrace.rs:399:19
    |
399 |     fn _assert<T: Send + Sync>() {}
    |                   ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/backtrace.rs:399:26
    |
399 |     fn _assert<T: Send + Sync>() {}
    |                          ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
  --> src/chain.rs:18:15
   |
18 |         next: Option<&'a (dyn StdError + 'static)>,
   |               ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Iterator` in this scope
  --> src/chain.rs:35:10
   |
35 | impl<'a> Iterator for Chain<'a> {
   |          ^^^^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
  --> src/chain.rs:38:27
   |
38 |     fn next(&mut self) -> Option<Self::Item> {
   |                           ^^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
  --> src/chain.rs:50:36
   |
50 |     fn size_hint(&self) -> (usize, Option<usize>) {
   |                                    ^^^^^^ not found in this scope

error[E0405]: cannot find trait `DoubleEndedIterator` in this scope
  --> src/chain.rs:57:6
   |
57 | impl DoubleEndedIterator for Chain<'_> {
   |      ^^^^^^^^^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
  --> src/chain.rs:58:32
   |
58 |     fn next_back(&mut self) -> Option<Self::Item> {
   |                                ^^^^^^ not found in this scope

error[E0405]: cannot find trait `ExactSizeIterator` in this scope
  --> src/chain.rs:76:6
   |
76 | impl ExactSizeIterator for Chain<'_> {
   |      ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0405]: cannot find trait `Default` in this scope
  --> src/chain.rs:94:6
   |
94 | impl Default for Chain<'_> {
   |      ^^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:15:26
   |
15 |             C: Display + Send + Sync + 'static;
   |                          ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:15:33
   |
15 |             C: Display + Send + Sync + 'static;
   |                                 ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:21:32
   |
21 |         E: std::error::Error + Send + Sync + 'static,
   |                                ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:21:39
   |
21 |         E: std::error::Error + Send + Sync + 'static,
   |                                       ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:25:26
   |
25 |             C: Display + Send + Sync + 'static,
   |                          ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:25:33
   |
25 |             C: Display + Send + Sync + 'static,
   |                                 ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:35:26
   |
35 |             C: Display + Send + Sync + 'static,
   |                          ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:35:33
   |
35 |             C: Display + Send + Sync + 'static,
   |                                 ^^^^ not found in this scope

error[E0412]: cannot find type `Result` in this scope
  --> src/context.rs:42:30
   |
42 | impl<T, E> Context<T, E> for Result<T, E>
   |                              ^^^^^^ not found in this scope
   |
help: consider importing this type alias
   |
1  + use crate::Result;
   |

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:44:24
   |
44 |     E: ext::StdError + Send + Sync + 'static,
   |                        ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:44:31
   |
44 |     E: ext::StdError + Send + Sync + 'static,
   |                               ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:48:22
   |
48 |         C: Display + Send + Sync + 'static,
   |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:48:29
   |
48 |         C: Display + Send + Sync + 'static,
   |                             ^^^^ not found in this scope

error[E0412]: cannot find type `Result` in this scope
  --> src/context.rs:46:40
   |
46 |     fn context<C>(self, context: C) -> Result<T, Error>
   |                                        ^^^^^^ not found in this scope
   |
help: consider importing this type alias
   |
1  + use crate::Result;
   |

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:60:22
   |
60 |         C: Display + Send + Sync + 'static,
   |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:60:29
   |
60 |         C: Display + Send + Sync + 'static,
   |                             ^^^^ not found in this scope

error[E0405]: cannot find trait `FnOnce` in this scope
  --> src/context.rs:61:12
   |
61 |         F: FnOnce() -> C,
   |            ^^^^^^ not found in this scope

error[E0412]: cannot find type `Result` in this scope
  --> src/context.rs:58:48
   |
58 |     fn with_context<C, F>(self, context: F) -> Result<T, Error>
   |                                                ^^^^^^ not found in this scope
   |
help: consider importing this type alias
   |
1  + use crate::Result;
   |

error[E0412]: cannot find type `Option` in this scope
  --> src/context.rs:90:36
   |
90 | impl<T> Context<T, Infallible> for Option<T> {
   |                                    ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/context.rs:93:22
   |
93 |         C: Display + Send + Sync + 'static,
   |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/context.rs:93:29
   |
93 |         C: Display + Send + Sync + 'static,
   |                             ^^^^ not found in this scope

error[E0412]: cannot find type `Result` in this scope
  --> src/context.rs:91:40
   |
91 |     fn context<C>(self, context: C) -> Result<T, Error>
   |                                        ^^^^^^ not found in this scope
   |
help: consider importing this type alias
   |
1  + use crate::Result;
   |

error[E0405]: cannot find trait `Send` in this scope
   --> src/context.rs:105:22
    |
105 |         C: Display + Send + Sync + 'static,
    |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/context.rs:105:29
    |
105 |         C: Display + Send + Sync + 'static,
    |                             ^^^^ not found in this scope

error[E0405]: cannot find trait `FnOnce` in this scope
   --> src/context.rs:106:12
    |
106 |         F: FnOnce() -> C,
    |            ^^^^^^ not found in this scope

error[E0412]: cannot find type `Result` in this scope
   --> src/context.rs:103:48
    |
103 |     fn with_context<C, F>(self, context: F) -> Result<T, Error>
    |                                                ^^^^^^ not found in this scope
    |
help: consider importing this type alias
    |
1   + use crate::Result;
    |

error[E0412]: cannot find type `Option` in this scope
   --> src/context.rs:142:25
    |
142 |     fn source(&self) -> Option<&(dyn StdError + 'static)> {
    |                         ^^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/context.rs:156:25
    |
156 |     fn source(&self) -> Option<&(dyn StdError + 'static)> {
    |                         ^^^^^^ not found in this scope

error[E0412]: cannot find type `Result` in this scope
   --> src/context.rs:191:27
    |
191 |     impl<T, E> Sealed for Result<T, E> where E: ext::StdError {}
    |                           ^^^^^^ not found in this scope
    |
help: consider importing this type alias
    |
187 +     use crate::Result;
    |

error[E0412]: cannot find type `Option` in this scope
   --> src/context.rs:192:24
    |
192 |     impl<T> Sealed for Option<T> {}
    |                        ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/error.rs:34:23
   |
34 |         E: StdError + Send + Sync + 'static,
   |                       ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/error.rs:34:30
   |
34 |         E: StdError + Send + Sync + 'static,
   |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/error.rs:81:30
   |
81 |         M: Display + Debug + Send + Sync + 'static,
   |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/error.rs:81:37
   |
81 |         M: Display + Debug + Send + Sync + 'static,
   |                                     ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/error.rs:90:23
   |
90 |         E: StdError + Send + Sync + 'static,
   |                       ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/error.rs:90:30
   |
90 |         E: StdError + Send + Sync + 'static,
   |                              ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
  --> src/error.rs:88:52
   |
88 |     pub(crate) fn from_std<E>(error: E, backtrace: Option<Backtrace>) -> Self
   |                                                    ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:113:30
    |
113 |         M: Display + Debug + Send + Sync + 'static,
    |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:113:37
    |
113 |         M: Display + Debug + Send + Sync + 'static,
    |                                     ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:111:56
    |
111 |     pub(crate) fn from_adhoc<M>(message: M, backtrace: Option<Backtrace>) -> Self
    |                                                        ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:139:22
    |
139 |         M: Display + Send + Sync + 'static,
    |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:139:29
    |
139 |         M: Display + Send + Sync + 'static,
    |                             ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:137:58
    |
137 |     pub(crate) fn from_display<M>(message: M, backtrace: Option<Backtrace>) -> Self
    |                                                          ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:166:22
    |
166 |         C: Display + Send + Sync + 'static,
    |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:166:29
    |
166 |         C: Display + Send + Sync + 'static,
    |                             ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:167:23
    |
167 |         E: StdError + Send + Sync + 'static,
    |                       ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:167:30
    |
167 |         E: StdError + Send + Sync + 'static,
    |                              ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:164:71
    |
164 |     pub(crate) fn from_context<C, E>(context: C, error: E, backtrace: Option<Backtrace>) -> Self
    |                                                                       ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:192:35
    |
192 |         error: Box<dyn StdError + Send + Sync>,
    |                                   ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:192:42
    |
192 |         error: Box<dyn StdError + Send + Sync>,
    |                                          ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:193:20
    |
193 |         backtrace: Option<Backtrace>,
    |                    ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:228:23
    |
228 |         E: StdError + Send + Sync + 'static,
    |                       ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:228:30
    |
228 |         E: StdError + Send + Sync + 'static,
    |                              ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:225:20
    |
225 |         backtrace: Option<Backtrace>,
    |                    ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:303:22
    |
303 |         C: Display + Send + Sync + 'static,
    |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:303:29
    |
303 |         C: Display + Send + Sync + 'static,
    |                             ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:416:30
    |
416 |         E: Display + Debug + Send + Sync + 'static,
    |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:416:37
    |
416 |         E: Display + Debug + Send + Sync + 'static,
    |                                     ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:424:30
    |
424 |         E: Display + Debug + Send + Sync + 'static,
    |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:424:37
    |
424 |         E: Display + Debug + Send + Sync + 'static,
    |                                     ^^^^ not found in this scope

error[E0412]: cannot find type `Result` in this scope
   --> src/error.rs:422:37
    |
422 |     pub fn downcast<E>(mut self) -> Result<E, Self>
    |                                     ^^^^^^ not found in this scope
    |
help: consider importing this type alias
    |
1   + use crate::Result;
    |

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:494:30
    |
494 |         E: Display + Debug + Send + Sync + 'static,
    |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:494:37
    |
494 |         E: Display + Debug + Send + Sync + 'static,
    |                                     ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:492:38
    |
492 |     pub fn downcast_ref<E>(&self) -> Option<&E>
    |                                      ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:508:30
    |
508 |         E: Display + Debug + Send + Sync + 'static,
    |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:508:37
    |
508 |         E: Display + Debug + Send + Sync + 'static,
    |                                     ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:506:42
    |
506 |     pub fn downcast_mut<E>(&mut self) -> Option<&mut E>
    |                                          ^^^^^^ not found in this scope

error[E0405]: cannot find trait `From` in this scope
   --> src/error.rs:545:9
    |
545 | impl<E> From<E> for Error
    |         ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:547:19
    |
547 |     E: StdError + Send + Sync + 'static,
    |                   ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:547:26
    |
547 |     E: StdError + Send + Sync + 'static,
    |                          ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:559:34
    |
559 |     type Target = dyn StdError + Send + Sync + 'static;
    |                                  ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:559:41
    |
559 |     type Target = dyn StdError + Send + Sync + 'static;
    |                                         ^^^^ not found in this scope

error[E0405]: cannot find trait `Drop` in this scope
   --> src/error.rs:586:6
    |
586 | impl Drop for Error {
    |      ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:597:65
    |
597 |     object_ref: unsafe fn(Ref<ErrorImpl>) -> Ref<dyn StdError + Send + Sync + 'static>,
    |                                                                 ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:597:72
    |
597 |     object_ref: unsafe fn(Ref<ErrorImpl>) -> Ref<dyn StdError + Send + Sync + 'static>,
    |                                                                        ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:600:67
    |
600 |     object_boxed: unsafe fn(Own<ErrorImpl>) -> Box<dyn StdError + Send + Sync + 'static>,
    |                                                                   ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:600:74
    |
600 |     object_boxed: unsafe fn(Own<ErrorImpl>) -> Box<dyn StdError + Send + Sync + 'static>,
    |                                                                          ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:601:59
    |
601 |     object_downcast: unsafe fn(Ref<ErrorImpl>, TypeId) -> Option<Ref<()>>,
    |                                                           ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:630:19
    |
630 |     E: StdError + Send + Sync + 'static,
    |                   ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:630:26
    |
630 |     E: StdError + Send + Sync + 'static,
    |                          ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:628:66
    |
628 | unsafe fn object_ref<E>(e: Ref<ErrorImpl>) -> Ref<dyn StdError + Send + Sync + 'static>
    |                                                                  ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:628:73
    |
628 | unsafe fn object_ref<E>(e: Ref<ErrorImpl>) -> Ref<dyn StdError + Send + Sync + 'static>
    |                                                                         ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:659:19
    |
659 |     E: StdError + Send + Sync + 'static,
    |                   ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:659:26
    |
659 |     E: StdError + Send + Sync + 'static,
    |                          ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:657:68
    |
657 | unsafe fn object_boxed<E>(e: Own<ErrorImpl>) -> Box<dyn StdError + Send + Sync + 'static>
    |                                                                    ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:657:75
    |
657 | unsafe fn object_boxed<E>(e: Own<ErrorImpl>) -> Box<dyn StdError + Send + Sync + 'static>
    |                                                                           ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:666:68
    |
666 | unsafe fn object_downcast<E>(e: Ref<ErrorImpl>, target: TypeId) -> Option<Ref<()>>
    |                                                                    ^^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:715:72
    |
715 | unsafe fn context_downcast<C, E>(e: Ref<ErrorImpl>, target: TypeId) -> Option<Ref<()>>
    |                                                                        ^^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:772:75
    |
772 | unsafe fn context_chain_downcast<C>(e: Ref<ErrorImpl>, target: TypeId) -> Option<Ref<()>>
    |                                                                           ^^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:846:16
    |
846 |     backtrace: Option<Backtrace>,
    |                ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:877:69
    |
877 |     pub(crate) unsafe fn error(this: Ref<Self>) -> &(dyn StdError + Send + Sync + 'static) {
    |                                                                     ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:877:76
    |
877 |     pub(crate) unsafe fn error(this: Ref<Self>) -> &(dyn StdError + Send + Sync + 'static) {
    |                                                                            ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:884:77
    |
884 |     pub(crate) unsafe fn error_mut(this: Mut<Self>) -> &mut (dyn StdError + Send + Sync + 'static) {
    |                                                                             ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:884:84
    |
884 |     pub(crate) unsafe fn error_mut(this: Mut<Self>) -> &mut (dyn StdError + Send + Sync + 'static) {
    |                                                                                    ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
   --> src/error.rs:932:25
    |
932 |     fn source(&self) -> Option<&(dyn StdError + 'static)> {
    |                         ^^^^^^ not found in this scope

error[E0405]: cannot find trait `From` in this scope
   --> src/error.rs:960:6
    |
960 | impl From<Error> for Box<dyn StdError + Send + Sync + 'static> {
    |      ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:960:41
    |
960 | impl From<Error> for Box<dyn StdError + Send + Sync + 'static> {
    |                                         ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:960:48
    |
960 | impl From<Error> for Box<dyn StdError + Send + Sync + 'static> {
    |                                                ^^^^ not found in this scope

error[E0405]: cannot find trait `From` in this scope
   --> src/error.rs:972:6
    |
972 | impl From<Error> for Box<dyn StdError + Send + 'static> {
    |      ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:972:41
    |
972 | impl From<Error> for Box<dyn StdError + Send + 'static> {
    |                                         ^^^^ not found in this scope

error[E0405]: cannot find trait `From` in this scope
   --> src/error.rs:978:6
    |
978 | impl From<Error> for Box<dyn StdError + 'static> {
    |      ^^^^ not found in this scope

error[E0405]: cannot find trait `AsRef` in this scope
   --> src/error.rs:985:6
    |
985 | impl AsRef<dyn StdError + Send + Sync> for Error {
    |      ^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:985:27
    |
985 | impl AsRef<dyn StdError + Send + Sync> for Error {
    |                           ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:985:34
    |
985 | impl AsRef<dyn StdError + Send + Sync> for Error {
    |                                  ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/error.rs:986:42
    |
986 |     fn as_ref(&self) -> &(dyn StdError + Send + Sync + 'static) {
    |                                          ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/error.rs:986:49
    |
986 |     fn as_ref(&self) -> &(dyn StdError + Send + Sync + 'static) {
    |                                                 ^^^^ not found in this scope

error[E0405]: cannot find trait `AsRef` in this scope
   --> src/error.rs:992:6
    |
992 | impl AsRef<dyn StdError> for Error {
    |      ^^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
  --> src/fmt.rs:69:13
   |
69 |     number: Option<usize>,
   |             ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/kind.rs:56:22
   |
56 | pub trait AdhocKind: Sized {
   |                      ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/kind.rs:63:36
   |
63 | impl<T> AdhocKind for &T where T: ?Sized + Display + Debug + Send + Sync + 'static {}
   |                                    ^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/kind.rs:63:62
   |
63 | impl<T> AdhocKind for &T where T: ?Sized + Display + Debug + Send + Sync + 'static {}
   |                                                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/kind.rs:63:69
   |
63 | impl<T> AdhocKind for &T where T: ?Sized + Display + Debug + Send + Sync + 'static {}
   |                                                                     ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/kind.rs:69:30
   |
69 |         M: Display + Debug + Send + Sync + 'static,
   |                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/kind.rs:69:37
   |
69 |         M: Display + Debug + Send + Sync + 'static,
   |                                     ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/kind.rs:78:22
   |
78 | pub trait TraitKind: Sized {
   |                      ^^^^^ not found in this scope

error[E0405]: cannot find trait `Into` in this scope
  --> src/kind.rs:85:34
   |
85 | impl<E> TraitKind for E where E: Into<Error> {}
   |                                  ^^^^ not found in this scope

error[E0405]: cannot find trait `Into` in this scope
  --> src/kind.rs:91:12
   |
91 |         E: Into<Error>,
   |            ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
   --> src/kind.rs:102:22
    |
102 | pub trait BoxedKind: Sized {
    |                      ^^^^^ not found in this scope

error[E0412]: cannot find type `Box` in this scope
   --> src/kind.rs:110:20
    |
110 | impl BoxedKind for Box<dyn StdError + Send + Sync> {}
    |                    ^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/kind.rs:110:39
    |
110 | impl BoxedKind for Box<dyn StdError + Send + Sync> {}
    |                                       ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/kind.rs:110:46
    |
110 | impl BoxedKind for Box<dyn StdError + Send + Sync> {}
    |                                              ^^^^ not found in this scope

error[E0412]: cannot find type `Box` in this scope
   --> src/kind.rs:115:29
    |
115 |     pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
    |                             ^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/kind.rs:115:48
    |
115 |     pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
    |                                                ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/kind.rs:115:55
    |
115 |     pub fn new(self, error: Box<dyn StdError + Send + Sync>) -> Error {
    |                                                       ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
 --> src/ptr.rs:8:9
  |
8 |     T: ?Sized,
  |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/ptr.rs:13:16
   |
13 | unsafe impl<T> Send for Own<T> where T: ?Sized {}
   |                ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:13:42
   |
13 | unsafe impl<T> Send for Own<T> where T: ?Sized {}
   |                                          ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/ptr.rs:15:16
   |
15 | unsafe impl<T> Sync for Own<T> where T: ?Sized {}
   |                ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:15:42
   |
15 | unsafe impl<T> Sync for Own<T> where T: ?Sized {}
   |                                          ^^^^^ not found in this scope

error[E0405]: cannot find trait `Copy` in this scope
  --> src/ptr.rs:17:9
   |
17 | impl<T> Copy for Own<T> where T: ?Sized {}
   |         ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:17:35
   |
17 | impl<T> Copy for Own<T> where T: ?Sized {}
   |                                   ^^^^^ not found in this scope

error[E0405]: cannot find trait `Clone` in this scope
  --> src/ptr.rs:19:9
   |
19 | impl<T> Clone for Own<T>
   |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:21:9
   |
21 |     T: ?Sized,
   |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:30:9
   |
30 |     T: ?Sized,
   |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:66:9
   |
66 |     T: ?Sized,
   |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Copy` in this scope
  --> src/ptr.rs:72:13
   |
72 | impl<'a, T> Copy for Ref<'a, T> where T: ?Sized {}
   |             ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:72:43
   |
72 | impl<'a, T> Copy for Ref<'a, T> where T: ?Sized {}
   |                                           ^^^^^ not found in this scope

error[E0405]: cannot find trait `Clone` in this scope
  --> src/ptr.rs:74:13
   |
74 | impl<'a, T> Clone for Ref<'a, T>
   |             ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:76:9
   |
76 |     T: ?Sized,
   |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
  --> src/ptr.rs:85:9
   |
85 |     T: ?Sized,
   |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
   --> src/ptr.rs:130:9
    |
130 |     T: ?Sized,
    |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Copy` in this scope
   --> src/ptr.rs:136:13
    |
136 | impl<'a, T> Copy for Mut<'a, T> where T: ?Sized {}
    |             ^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
   --> src/ptr.rs:136:43
    |
136 | impl<'a, T> Copy for Mut<'a, T> where T: ?Sized {}
    |                                           ^^^^^ not found in this scope

error[E0405]: cannot find trait `Clone` in this scope
   --> src/ptr.rs:138:13
    |
138 | impl<'a, T> Clone for Mut<'a, T>
    |             ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
   --> src/ptr.rs:140:9
    |
140 |     T: ?Sized,
    |         ^^^^^ not found in this scope

error[E0405]: cannot find trait `Sized` in this scope
   --> src/ptr.rs:149:9
    |
149 |     T: ?Sized,
    |         ^^^^^ not found in this scope

error[E0412]: cannot find type `Box` in this scope
  --> src/wrapper.rs:55:27
   |
55 | pub struct BoxedError(pub Box<dyn StdError + Send + Sync>);
   |                           ^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
  --> src/wrapper.rs:55:46
   |
55 | pub struct BoxedError(pub Box<dyn StdError + Send + Sync>);
   |                                              ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
  --> src/wrapper.rs:55:53
   |
55 | pub struct BoxedError(pub Box<dyn StdError + Send + Sync>);
   |                                                     ^^^^ not found in this scope

error[E0412]: cannot find type `Option` in this scope
  --> src/wrapper.rs:73:25
   |
73 |     fn source(&self) -> Option<&(dyn StdError + 'static)> {
   |                         ^^^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/lib.rs:606:22
    |
606 |         C: Display + Send + Sync + 'static;
    |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/lib.rs:606:29
    |
606 |         C: Display + Send + Sync + 'static;
    |                             ^^^^ not found in this scope

error[E0405]: cannot find trait `Send` in this scope
   --> src/lib.rs:612:22
    |
612 |         C: Display + Send + Sync + 'static,
    |                      ^^^^ not found in this scope

error[E0405]: cannot find trait `Sync` in this scope
   --> src/lib.rs:612:29
    |
612 |         C: Display + Send + Sync + 'static,
    |                             ^^^^ not found in this scope

error[E0405]: cannot find trait `FnOnce` in this scope
   --> src/lib.rs:613:12
    |
613 |         F: FnOnce() -> C;
    |            ^^^^^^ not found in this scope

warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
 --> src/ptr.rs:8:8
  |
8 |     T: ?Sized,
  |        ^^^^^^

Some errors have detailed explanations: E0405, E0412, E0432, E0463.
For more information about an error, try `rustc --explain E0405`.
warning: `anyhow` (lib doc) generated 1 warning
error: could not document `anyhow`

Caused by:
  process didn't exit successfully: `~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/rustdoc --edition=2018 --crate-type lib --crate-name anyhow src/lib.rs --target x86_64-unknown-fuchsia -o /git/anyhow/target/x86_64-unknown-fuchsia/doc --cfg 'feature="default"' --cfg 'feature="std"' --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=118 -C metadata=4a7e1bc4f090cd82 -L dependency=/git/anyhow/target/x86_64-unknown-fuchsia/debug/deps -L dependency=/git/anyhow/target/debug/deps -Zunstable-options --cfg doc_cfg --generate-link-to-definition --extern-html-root-takes-precedence --crate-version 1.0.75` (exit status: 1)
```
</details>

<br>

**After:**

```console
error[E0463]: can't find crate for `core`
  |
  = note: the `x86_64-unknown-fuchsia` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-fuchsia`
  = help: consider building the standard library from source with `cargo build -Zbuild-std`

error[E0463]: can't find crate for `compiler_builtins`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0463`.
```