### PR TITLE
Always pass at least one `--target`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn do_main() -> Result<()> {
         );
     };
 
-    let mut doc_targets = Vec::new();
+    let mut doc_targets: Vec<&str> = Vec::new();
     if !args.target.is_empty() {
         for target in &args.target {
             doc_targets.push(target);
@@ -145,6 +145,10 @@ fn do_main() -> Result<()> {
         if !status.success() {
             process::exit(status.code().unwrap_or(1));
         }
+    }
+
+    if doc_targets.is_empty() && !proc_macro {
+        doc_targets.push(target_triple::HOST);
     }
 
     let mut rustflags = metadata.rustc_args.clone();


### PR DESCRIPTION
Fixes #11. Without `--target`, the `-Zhost-config` and `-Ztarget-applies-to-host` settings are ineffective.