### PR TITLE
Disable toml "parse" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ serde_path_to_error = "0.1"
 shlex = "1.3"
 target-triple = "0.1"
 termcolor = "1.4"
-toml = "0.8"
+toml = { version = "0.8", default-features = false, features = ["display"] }


### PR DESCRIPTION
The `toml` dependency is only used for serializing `--config` flags.

https://github.com/dtolnay/cargo-docs-rs/blob/d1368f65834b7dff5d246dd158d4117b677f9115/src/main.rs#L219-L221

We do not need support for parsing TOML in this crate.

**Before:**

```console
$ cargo tree -e features -i toml
toml v0.8.19
├── toml feature "default"
│   └── cargo-docs-rs v0.1.13 (/git/cargo-docs-rs)
│       └── cargo-docs-rs feature "default" (command-line)
├── toml feature "display"
│   └── toml feature "default" (*)
└── toml feature "parse"
    └── toml feature "default" (*)
```

**After:**

```console
$ cargo tree -e features -i toml
toml v0.8.19
└── toml feature "display"
    └── cargo-docs-rs v0.1.13 (/git/cargo-docs-rs)
        └── cargo-docs-rs feature "default" (command-line)
```