### PR TITLE
add missing scrape-examples argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,7 @@ fn do_main() -> Result<()> {
     cargo_rustdoc.arg("rustdoc");
     cargo_rustdoc.arg("-Zunstable-options");
     cargo_rustdoc.arg("-Zrustdoc-map");
+    cargo_rustdoc.arg("-Zrustdoc-scrape-examples");
     if !rustflags.is_empty() {
         cargo_rustdoc.arg("-Zhost-config");
         cargo_rustdoc.arg("-Ztarget-applies-to-host");


### PR DESCRIPTION
I regularly recommend this cargo command to docs.rs users so they can test the output, so thanks for this! 

After digging into a size difference in the actual docs.rs output and `cargo docs-rs` output I found this argument is missing. 

See also https://github.com/rust-lang/docs.rs/pull/1954 where it was added. 