### PR TITLE
add `-Zrustdoc-scrape-examples` to match docs.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -249,6 +249,7 @@ fn do_main() -> Result<()> {
         "--config",
         r#"doc.extern-map.registries.crates-io="https://docs.rs""#,
     );
+    cargo_rustdoc.arg("-Zrustdoc-scrape-examples");
 
     cargo_rustdoc.args(&metadata.cargo_args);
 


### PR DESCRIPTION
[docs.rs is also adding this arg](https://github.com/rust-lang/docs.rs/blob/7a6c393e89ad794e8555625722326ca4aa60051e/crates/bin/docs_rs_builder/src/docbuilder/rustwide_builder.rs#L1300-L1302), since https://github.com/rust-lang/docs.rs/pull/1954 , we should do it too. 

